### PR TITLE
stable openjdk version for Autofirma is 11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN unzip /tmp/autofirma.zip AutoFirma_*.deb -d /tmp
 FROM linuxserver/firefox:latest
 
 # Install AutoFirma.
-RUN apt-get update && apt-get -y install openjdk-21-jdk libnss3-tools
+RUN apt-get update && apt-get -y install openjdk-11-jdk libnss3-tools
 
 # Copy AutoFirma from the previous stage.
 COPY --from=autofirma_dl /tmp/AutoFirma_*.deb /tmp/


### PR DESCRIPTION
Hi!

Autofirma stable version seems to be OpenJdk-11, In this pull request I installed via DockerFile

cheers